### PR TITLE
Fix an off-by-1 error.

### DIFF
--- a/src/inner_constraint.cpp
+++ b/src/inner_constraint.cpp
@@ -94,9 +94,7 @@ InnerConstraint::InnerConstraint(
     vector<PII> hess_entries = stack.getHessEntries();
     FOREACH(p, hess_entries)
     //for (auto& p : hess_entries){
-        auto it = hess_pos_map.find(p);
-        if (it == hess_pos_map.end())
-            hess_pos_map[p] = hess_pos_map.size();
+        hess_pos_map.insert({p, hess_pos_map.size()}); // Only inserts if new.
         hess_map.push_back(hess_pos_map[p]);
     }
     hess.resize(hess_map.size());

--- a/src/inner_constraint.cpp
+++ b/src/inner_constraint.cpp
@@ -96,7 +96,7 @@ InnerConstraint::InnerConstraint(
     //for (auto& p : hess_entries){
         auto it = hess_pos_map.find(p);
         if (it == hess_pos_map.end())
-            hess_pos_map[p] = hess_pos_map.size() - 1;
+            hess_pos_map[p] = hess_pos_map.size();
         hess_map.push_back(hess_pos_map[p]);
     }
     hess.resize(hess_map.size());


### PR DESCRIPTION
Hi Karsten,

There appears to be an off-by-1 error in inner_constraint.cpp. Making this change fixed a segfault I was getting, and thereafter everything seemed normal. But I don't understand the code enough to know if, for example, this change breaks anything.

Annotations below:
```
hess_pos_map[p] = hess_pos_map.size() - 1; // <=== 1st entry into hess_pos_map is -1.
hess_map.push_back(hess_pos_map[p]); // <=== hess_map elems are unsigned, so -1 -> large +ve int.
```