### PR TITLE
Fix memory issue that manifested on Beaglebone Black.

### DIFF
--- a/src/inner_constraint.cpp
+++ b/src/inner_constraint.cpp
@@ -162,22 +162,22 @@ void InnerConstraint::setEvals(CStack& stack){
 
 const double& InnerConstraint::getNextValue(Idx& idx){
     ASSERT_LE(idx, data.size()-1);
-    return reinterpret_cast<const double&>(data[idx++]);
+    return data[idx++].d;
 }
 
 Idx InnerConstraint::getNextCounter(Idx& idx){
     ASSERT_LE(idx, data.size()-1);
-    return data[idx++];
+    return data[idx++].idx;
 }
 
 const Idx& InnerConstraint::getNextPos(Idx& idx){
     ASSERT_LE(idx, data.size()-1);
-    return (reinterpret_cast<InnerVar*>(data[idx++]))->getPos();
+    return (data[idx++].iVar)->getPos();
 }
 
 const double& InnerConstraint::getNextParamValue(Idx& idx){
     ASSERT_LE(idx, data.size()-1);
-    return (reinterpret_cast<InnerParam*>(data[idx++]))->value();
+    return (data[idx++].iParam)->value();
 }
 
 #define MADOPTCASE(a) case OP_##a: case##a(stack); break;

--- a/src/inner_constraint.hpp
+++ b/src/inner_constraint.hpp
@@ -21,6 +21,7 @@
 #include "common.hpp"
 #include "array.hpp"
 #include "constraint_interface.hpp"
+#include "value.hpp"
 
 namespace MadOpt {
 
@@ -90,7 +91,7 @@ class InnerConstraint: public ConstraintInterface{
 
         vector<OPType> operators;
 
-        vector<uintptr_t> data;
+        vector<Value> data;
 
         double g;
 

--- a/src/operator.hpp
+++ b/src/operator.hpp
@@ -20,6 +20,7 @@
 #include "inner_var.hpp"
 #include "inner_param.hpp"
 #include "exceptions.hpp"
+#include "value.hpp"
 
 #define OP_VAR_POINTER 0
 #define OP_CONST 1
@@ -44,19 +45,16 @@ typedef char OPType;
 class Operator{
     public:
 
-        Operator(OPType t, InnerVar* var):type(t){ 
+        Operator(OPType t, InnerVar* var):type(t),value(var){ 
             checkVarPointer();
-            value = reinterpret_cast<uintptr_t>(var); 
         }
 
-        Operator(OPType t, InnerParam* var):type(t){ 
+        Operator(OPType t, InnerParam* var):type(t),value(var){ 
             checkParam();
-            value = reinterpret_cast<uintptr_t>(var); 
         }
 
-        Operator(OPType t, double v): type(t){ 
+        Operator(OPType t, double v): type(t),value(v){
             checkDouble();
-            setValue(v); 
         }
 
         Operator(OPType t, Idx p): type(t), value(p){
@@ -73,7 +71,7 @@ class Operator{
             checkNone();
         }
 
-        const uintptr_t& getData() const {
+        const Value& getData() const {
             return value;
         }
 
@@ -83,37 +81,37 @@ class Operator{
 
         const Idx getIndex()const { 
             checkVarIdx();
-            return value; 
+            return value.idx; 
         }
 
         const Idx getCounter()const { 
             checkCounter();
-            return value; 
+            return value.idx; 
         }
 
         double getValue()const { 
             checkDouble();
-            return reinterpret_cast<const double&>(value); 
+            return value.d;
         }
 
         InnerVar* getIVar()const { 
             checkVarPointer();
-            return reinterpret_cast<InnerVar*>(value); 
+            return value.iVar; 
         }
 
         InnerParam* getIParam()const { 
             checkParam();
-            return reinterpret_cast<InnerParam*>(value); 
+            return value.iParam; 
         }
 
         void setValue(double v){ 
             checkDouble();
-            value = *reinterpret_cast<uintptr_t*>(&v); 
+            value.d = v; 
         }
 
         void addToCounter(Idx v){ 
             checkCounter();
-            value += v; 
+            value.idx += v;
         }
 
         void modifyValue(double v, bool op){
@@ -124,13 +122,13 @@ class Operator{
 
         string toString()const {
             return std::to_string((long long int)type) + 
-                ": c=" + std::to_string((long long unsigned int)value) 
+                ": c=" + std::to_string((long long unsigned int)value.i) 
                 + " v=" + std::to_string((long double)getValue());
         }
 
     private:
         OPType type;
-        uintptr_t value;
+        Value value;
 
         void checkNone()const {
             if (type != OP_SIN && type != OP_COS && type != OP_TAN && type != OP_LOG2 && type != OP_LN)

--- a/src/value.hpp
+++ b/src/value.hpp
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2014 National ICT Australia Limited (NICTA)
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef MADOPT_VALUE_H
+#define MADOPT_VALUE_H
+
+#include "inner_var.hpp"
+#include "inner_param.hpp"
+
+namespace MadOpt {
+    union Value
+    {
+        InnerVar* iVar;
+        InnerParam* iParam;
+        Idx idx;
+        double d;
+        int i;
+
+        Value() : i(0) {}
+        Value(InnerVar* x) : iVar(x) {}
+        Value(InnerParam* x) : iParam(x) {}
+        Value(Idx x) : idx(x) {}
+        Value(double x) : d(x) {}
+        Value(int x) : i(x) {}
+    };
+}
+
+#endif
+/* ex: set tabstop=4 shiftwidth=4 expandtab: */


### PR DESCRIPTION
This problem was due to the fact that uintptr_t is 4 bytes on the BBB, but was being used to store 8 byte doubles via reinterpret_cast.

I have changed the code from using uintptr_t to using a union. I have tested using the examples/get_started.cpp code on my mac (clang), with identical output and nearly identical timing.